### PR TITLE
0.8.0-beta.1

### DIFF
--- a/examples/macro_expand/Cargo.lock
+++ b/examples/macro_expand/Cargo.lock
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.5"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9d66b91e902db43baefd8e40c8678ce29db2cf1d88ebd715174368d5fe70a9"
+checksum = "ddad16e8529759736a9ce4cdf078ed702e45d3c5b0474a1c65f5149e9fa7f1eb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "toy-rpc"
-version = "0.8.0-alpha.3"
+version = "0.8.0-beta.0"
 dependencies = [
  "async-std",
  "async-trait",

--- a/examples/macro_expand/src/lib.rs
+++ b/examples/macro_expand/src/lib.rs
@@ -8,6 +8,7 @@ use serde::{Serialize, Deserialize};
 /*                                #[derive(Topic)]                            */
 /* -------------------------------------------------------------------------- */
 #[derive(Serialize, Deserialize, Topic)]
+#[topic(rename="YourTopic")]
 pub struct MyTopic(u32);
 
 

--- a/examples/macro_expand/src/lib.rs
+++ b/examples/macro_expand/src/lib.rs
@@ -8,7 +8,7 @@ use serde::{Serialize, Deserialize};
 /*                                #[derive(Topic)]                            */
 /* -------------------------------------------------------------------------- */
 #[derive(Serialize, Deserialize, Topic)]
-#[topic(rename="YourTopic")]
+#[topic(rename="YourTopic", item="u32")]
 pub struct MyTopic(u32);
 
 

--- a/examples/tokio_pubsub/src/bin/publisher.rs
+++ b/examples/tokio_pubsub/src/bin/publisher.rs
@@ -18,7 +18,9 @@ async fn main() {
     let mut count = 90;
     // immediately dropping the client will not have the message fully sent
     while count >= 0  {
-        count_pub.send(Count(count)).await.unwrap();
+        // let item = Count(count);
+        let item = count;
+        count_pub.send(item).await.unwrap();
         count -= 1;
         tokio::time::sleep(Duration::from_millis(500)).await; 
     }

--- a/examples/tokio_pubsub/src/bin/server.rs
+++ b/examples/tokio_pubsub/src/bin/server.rs
@@ -21,7 +21,9 @@ async fn main() {
     task::spawn(async move {
         let mut count = 0;
         loop {
-            count_pub.send(Count(count)).await.unwrap();
+            // let item = Count(count);
+            let item = count;
+            count_pub.send(item).await.unwrap();
             count += 1;
             tokio::time::sleep(Duration::from_millis(1000)).await;
         }

--- a/examples/tokio_pubsub/src/lib.rs
+++ b/examples/tokio_pubsub/src/lib.rs
@@ -5,6 +5,7 @@ use toy_rpc::macros::Topic;
 pub const ADDR: &str = "127.0.0.1:23333";
 
 #[derive(Debug, Topic, Serialize, Deserialize)]
+#[topic(rename="C", item="u32")]
 pub struct Count(pub u32);
 
 // impl Topic for Count {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toy-rpc-macros"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Minghua Wu <michael.wu1107@gmail.com>"]
 edition = "2018"
 description = "Macros for toy-rpc"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -535,12 +535,27 @@ pub fn export_trait_impl(
 /*                              #[derive(Topic)]                              */
 /* -------------------------------------------------------------------------- */
 
+use darling::{FromDeriveInput};
+
+#[derive(Debug, Default, FromDeriveInput)]
+#[darling(attributes(topic))]
+struct TopicAttr {
+    #[darling(default)]
+    rename: Option<String>,
+    #[darling(default)]
+    item: Option<syn::Ident>,
+}
+
 /// Implements `toy_rpc::pubsub::Topic` trait for a type. The type will also be
 /// the  associated type `Topic::Item`, and thus the derived type must implement
 /// both `serde::Serialize` and `serde::Deserialize`.
-#[proc_macro_derive(Topic)]
+#[proc_macro_derive(Topic, attributes(topic))]
 pub fn derive_topic(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+
     let input = syn::parse_macro_input!(item as syn::DeriveInput);
+    // println!("{:?}", &input);
+    let topic_arg_opts = TopicAttr::from_derive_input(&input);
+    println!("{:?}", &topic_arg_opts);
     let ident = input.ident;
     let topic = ident.to_string();
 

--- a/toy-rpc/Cargo.toml
+++ b/toy-rpc/Cargo.toml
@@ -58,7 +58,7 @@ actix-web = "3.3"
 
 [dependencies]
 # local imports
-toy-rpc-macros = { version = "0.6.0", path="../macros" }
+toy-rpc-macros = { version = "0.6.1", path="../macros" }
 # toy-rpc-macros = "0.6.0"
 
 # feature gated optional dependecies

--- a/toy-rpc/Cargo.toml
+++ b/toy-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toy-rpc"
-version = "0.8.0-beta.0"
+version = "0.8.0-beta.1"
 authors = ["Minghua Wu <michael.wu1107@gmail.com>"]
 edition = "2018"
 description = "An async RPC that mimics golang net/rpc's usage and supports both async-std and tokio"
@@ -58,8 +58,8 @@ actix-web = "3.3"
 
 [dependencies]
 # local imports
-toy-rpc-macros = { version = "0.6.1", path="../macros" }
-# toy-rpc-macros = "0.6.0"
+# toy-rpc-macros = { version = "0.6.1", path="../macros" }
+toy-rpc-macros = "0.6.1"
 
 # feature gated optional dependecies
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
Added attribute `#[topic(rename="name", item="u32")]` to allow customizing the topic name and item type with the `Topic` derive macro.

Example

```rust
#[derive(Topic)]
#[topic(rename="C", item="u32")] // The topic name will be "C" instead of "Count", and the message item type will be `u32`
pub struct Count { }
```